### PR TITLE
Added *.exe to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /doc
 /.mypy_cache
 /.venv
+*.exe


### PR DESCRIPTION
Считаю, что стоит добавить *.exe файлы в .gitignore, чтобы при тестировании или сборке исполняемые файлы не попадали в коммиты по неосторожности.