### PR TITLE
Change build dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.mypy_cache
 /.venv
 *.exe
+.build

--- a/clean.py
+++ b/clean.py
@@ -1,0 +1,7 @@
+import shutil
+
+def clean():
+  print("Performing clean...")
+  print('Removing "doc" directory...')
+  shutil.rmtree("./doc")
+  print("Clean done.")

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ try:
 except FileNotFoundError:
     print("WARNING: couldn't get version from git.")
     full_version = f"{VERSION}-unknown"
-TMP = os.environ["TMP"]
-destination = rf"{TMP}\soundrts-{VERSION}-windows"
+destination = rf"./.build/{VERSION}"
 build_exe_options = {
     "build_exe": destination,
     "optimize": 1,
@@ -59,7 +58,6 @@ print("Creating empty user folder...")
 os.mkdir(rf"{destination}\user")
 print(r"Resetting cfg\language.txt ...")
 open(rf"{destination}\cfg\language.txt", "w").write("")
-Popen(rf'explorer /select,"{destination}"')
 print("Adding full_version.txt ...")
 with open(rf"{destination}\lib\full_version.txt", "w") as t:
     t.write(full_version)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ from cx_Freeze import Executable, setup
 
 import builddoc
 import buildmultimapslist
+import clean
 from soundrts.version import VERSION
 
 if platform.system() == "Windows" and ".venv" not in sys.executable:
@@ -43,6 +44,7 @@ executables = [
     Executable("server.py", base=None),
 ]
 
+clean.clean()
 buildmultimapslist.build()
 builddoc.build()
 if os.path.exists(destination):


### PR DESCRIPTION
Папка для сборки изменена.
Раньше сборка размещалась во временной папке системы.
Теперь сборка размещается в подкаталоге .build/<версия-сборки>.

Также, добавлен скрипт, выполняющий очистку некоторых временных файлов перед сборкой. В частности, удаляется папка "doc", чтобы устаревшая документация не попадала в готовую сборку.


Также, удалена команда, которая открывала папку с готовой сборкой в проводнике. Эта команда вызывала проблемы при сборке на linux и macOS, так как на этих системах отсутствует windows explorer.